### PR TITLE
feat: Update title and content of article

### DIFF
--- a/articles/efk-on-separate-cluster-20240423.md
+++ b/articles/efk-on-separate-cluster-20240423.md
@@ -1,12 +1,20 @@
 ---
-title: "Fluentd+ElasticSearch+KibanaでKubernetes上のログを収集して可視化する"
+title: "ElasticSearch+fluentd+KibanaでKubernetes上のログを収集して保存&可視化する"
 emoji: "🤛🏻"
 type: "tech" # tech: 技術記事 / idea: アイデア
-topics: []
+topics: ["kubernetes","fluentd","elasticsearch","kibana"]
 published: false
 ---
 
 # はじめに
-LKE(Linode Kubernetes Engine)上に構築されているwebアプリケーションのログを外部ストレージに保存し、他所にデプロイされたElasticSearch+Kibanaで可視化するまでのプロセスと注意点をまとめます。
+この記事ではKubernetes上に構築されているwebアプリケーションのログを収集し、ElasticSearchとKibanaでそれらを可視化するまでのプロセスをまとめます。
 
-# EFK(**E**lasticSearch+**F**luentd+**K**ibana)スタックについて
+手順としては、Kubernetesクラスタ内の各コンテナのログをfluentdコンテナで取り込み、ログ収集クラスタ上にデプロイされたElasticSearchに転送します。転送した後、外部ストレージもしくはローカルストレージにログを保存し、Kibanaによるログの視覚的に検索・解析を可能にします。
+
+# 使用したアプリケーション
+- ElasticSearch
+Javaで書かれているデータ検索分析エンジン。収集したログの分析、検索処理に使われます。
+- Fluentd
+`td-agent`とも。ログ収集・転送ソフトウェア。Kubernetes上のアプリケーションのログを収集し、ElasticSearchへと転送、格納します。
+- Kibana
+データ視覚化ツール。ElasticSearchのフロントエンドとして利用します。


### PR DESCRIPTION
Updated the title of the article to "ElasticSearch+fluentd+KibanaでKubernetes上のログを収集して保存&可視化する" and revised the content to focus on the process of collecting and visualizing logs on Kubernetes using Elasticsearch, Fluentd, and Kibana. Included details about the applications used in the process.